### PR TITLE
Create simple interface for exporting data

### DIFF
--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -2,5 +2,69 @@ require "art_vandelay/version"
 require "art_vandelay/engine"
 
 module ArtVandelay
-  # Your code goes here...
+  mattr_accessor :filtered_attributes
+  @@filtered_attributes = [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]
+
+  def self.setup
+    yield self
+  end
+
+  class Export
+    def initialize(records, export_sensitive_data: false, attributes: [])
+      @records = records
+      @export_sensitive_data = export_sensitive_data
+      @attributes = attributes
+    end
+
+    def csv
+      CSV.parse(generate_csv, headers: true)
+    end
+
+    private
+
+    attr_reader :records, :export_sensitive_data, :attributes
+
+    def filtered_values(attributes)
+      if export_sensitive_data
+        ActiveSupport::ParameterFilter.new([]).filter(attributes).values
+      else
+        ActiveSupport::ParameterFilter.new(ArtVandelay.filtered_attributes).filter(attributes).values
+      end
+    end
+
+    def generate_csv
+      CSV.generate do |csv|
+        csv << header
+        records.each do |record|
+          csv << row(record.attributes)
+        end
+      end
+    end
+
+    def header
+      if attributes.any?
+        model.attribute_names.select do |column_name|
+          standardized_attributes.include?(column_name)
+        end
+      else
+        model.attribute_names
+      end
+    end
+
+    def model
+      records.model_name.name.constantize
+    end
+
+    def row(attributes)
+      if self.attributes.any?
+        filtered_values(attributes.slice(*standardized_attributes))
+      else
+        filtered_values(attributes)
+      end
+    end
+
+    def standardized_attributes
+      attributes.map(&:to_s)
+    end
+  end
 end

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -1,7 +1,95 @@
 require "test_helper"
+require "csv"
 
 class ArtVandelayTest < ActiveSupport::TestCase
-  test "it has a version number" do
-    assert ArtVandelay::VERSION
+  class VERSION < ArtVandelayTest
+    test "it has a version number" do
+      assert ArtVandelay::VERSION
+    end
+  end
+
+  class Setup < ArtVandelayTest
+    test "it has the correct default values" do
+      filtered_attributes = ArtVandelay.filtered_attributes
+
+      assert_equal(
+        [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn],
+        filtered_attributes
+      )
+    end
+  end
+
+  class Export < ArtVandelayTest
+    test "it returns a CSV::Table instance" do
+      User.create!(email: "user@xample.com", password: "password")
+
+      result = ArtVandelay::Export.new(User.all).csv
+
+      assert_instance_of CSV::Table, result
+    end
+
+    test "it creates a CSV containing the correct data" do
+      user = User.create!(email: "user@xample.com", password: "password")
+
+      csv = ArtVandelay::Export.new(User.all).csv
+
+      assert_equal(
+        [
+          ["id", "email", "password", "created_at", "updated_at"],
+          [user.id.to_s, user.email.to_s, "[FILTERED]", user.created_at.to_s, user.updated_at.to_s]
+        ],
+        csv.to_a
+      )
+      assert_equal(
+        ["id", "email", "password", "created_at", "updated_at"],
+        csv.headers
+      )
+    end
+
+    test "it controlls what data is filtered" do
+      user = User.create!(email: "user@xample.com", password: "password")
+      ArtVandelay.setup do |config|
+        config.filtered_attributes << :email
+      end
+
+      csv = ArtVandelay::Export.new(User.all).csv
+
+      assert_equal(
+        [
+          ["id", "email", "password", "created_at", "updated_at"],
+          [user.id.to_s, "[FILTERED]", "[FILTERED]", user.created_at.to_s, user.updated_at.to_s]
+        ],
+        csv.to_a
+      )
+      ArtVandelay.filtered_attributes.delete(:email)
+    end
+
+    test "it allows for unfiltered exports" do
+      user = User.create!(email: "user@xample.com", password: "password")
+
+      csv = ArtVandelay::Export.new(User.all, export_sensitive_data: true).csv
+
+      assert_equal(
+        [
+          ["id", "email", "password", "created_at", "updated_at"],
+          [user.id.to_s, user.email.to_s, "password", user.created_at.to_s, user.updated_at.to_s]
+        ],
+        csv.to_a
+      )
+    end
+
+    test "it controlls what attributes are exported" do
+      user = User.create!(email: "user@xample.com", password: "password")
+
+      csv = ArtVandelay::Export.new(User.all, attributes: [:id, "email"]).csv
+
+      assert_equal(
+        [
+          ["id", "email"],
+          [user.id.to_s, user.email.to_s]
+        ],
+        csv.to_a
+      )
+    end
   end
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/test/dummy/db/migrate/20221008115344_create_users.rb
+++ b/test/dummy/db/migrate/20221008115344_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password, null: false
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_10_08_115344) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "password", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+end

--- a/test/dummy/test/fixtures/users.yml
+++ b/test/dummy/test/fixtures/users.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: user@example.com
+  password: Password

--- a/test/dummy/test/models/user_test.rb
+++ b/test/dummy/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This commit creates a simple interface for exporting data as a CSV in memory.

By default, the export will filter out sensitive data and export all attributes, but the caller can ultimately control what attributes are filtered and exported.