### PR TITLE
Send email with CSV attachment

### DIFF
--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -2,7 +2,7 @@ require "art_vandelay/version"
 require "art_vandelay/engine"
 
 module ArtVandelay
-  mattr_accessor :filtered_attributes
+  mattr_accessor :filtered_attributes, :from_address
   @@filtered_attributes = [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]
 
   def self.setup
@@ -10,6 +10,7 @@ module ArtVandelay
   end
 
   class Export
+    # TODO attributes: self.filtered_attributes
     def initialize(records, export_sensitive_data: false, attributes: [])
       @records = records
       @export_sensitive_data = export_sensitive_data
@@ -20,9 +21,23 @@ module ArtVandelay
       CSV.parse(generate_csv, headers: true)
     end
 
+    def email_csv(to:, from: ArtVandelay.from_address, subject: "#{model_name} export", body: "#{model_name} export")
+      mailer = ActionMailer::Base.mail(to: to, from: from, subject: subject, body: body)
+      mailer.attachments[file_name.to_s] = csv.to_csv
+
+      mailer.deliver
+    end
+
     private
 
     attr_reader :records, :export_sensitive_data, :attributes
+
+    def file_name
+      prefix = model_name.downcase
+      timestamp = Time.current.in_time_zone("UTC").strftime("%Y-%m-%d-%H-%M-%S-UTC")
+
+      "#{prefix}-export-#{timestamp}.csv"
+    end
 
     def filtered_values(attributes)
       if export_sensitive_data
@@ -52,7 +67,11 @@ module ArtVandelay
     end
 
     def model
-      records.model_name.name.constantize
+      model_name.constantize
+    end
+
+    def model_name
+      records.model_name.name
     end
 
     def row(attributes)

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -11,15 +11,19 @@ class ArtVandelayTest < ActiveSupport::TestCase
   class Setup < ArtVandelayTest
     test "it has the correct default values" do
       filtered_attributes = ArtVandelay.filtered_attributes
+      from_address = ArtVandelay.from_address
 
       assert_equal(
         [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn],
         filtered_attributes
       )
+      assert_nil from_address
     end
   end
 
   class Export < ArtVandelayTest
+    include ActionMailer::TestHelper
+
     test "it returns a CSV::Table instance" do
       User.create!(email: "user@xample.com", password: "password")
 
@@ -90,6 +94,100 @@ class ArtVandelayTest < ActiveSupport::TestCase
         ],
         csv.to_a
       )
+    end
+
+    test "it emails a CSV" do
+      travel_to Date.new(1989, 12, 31).beginning_of_day
+      user = User.create!(email: "user@xample.com", password: "password")
+
+      assert_emails 1 do
+        ArtVandelay::Export.new(User.all).email_csv(
+          to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+          from: "sender@example.com"
+        )
+      end
+
+      email = ActionMailer::Base.deliveries.last
+      csv = email.attachments.first
+
+      assert_equal(
+        ["recipient_1@examaple.com", "recipient_2@example.com"],
+        email.to
+      )
+      assert_equal(
+        [
+          ["id", "email", "password", "created_at", "updated_at"],
+          [user.id.to_s, user.email.to_s, "[FILTERED]", user.created_at.to_s, user.updated_at.to_s]
+        ],
+        CSV.parse(csv.body.raw_source)
+      )
+      assert_equal "user-export-1989-12-31-00-00-00-UTC.csv", csv.filename
+    end
+
+    test "it has a default subject" do
+      ArtVandelay::Export.new(User.all).email_csv(
+        to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+        from: "sender@example.com"
+      )
+      email = ActionMailer::Base.deliveries.last
+
+      assert_equal "User export", email.subject
+    end
+
+    test "it can set the subject" do
+      ArtVandelay::Export.new(User.all).email_csv(
+        to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+        from: "sender@example.com",
+        subject: "CUSTOM SUBJECT"
+      )
+      email = ActionMailer::Base.deliveries.last
+
+      assert_equal "CUSTOM SUBJECT", email.subject
+    end
+
+    test "it can set a from address" do
+      ArtVandelay::Export.new(User.all).email_csv(
+        to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+        from: "FROM@EMAIL.COM"
+      )
+      email = ActionMailer::Base.deliveries.last
+
+      assert_equal "FROM@EMAIL.COM", email.from.first
+    end
+
+    test "it can set a default from address" do
+      ArtVandelay.setup do |config|
+        config.from_address = "DEFAULT@EMAIL.COM"
+      end
+      ArtVandelay::Export.new(User.all).email_csv(
+        to: ["recipient_1@examaple.com", "recipient_2@example.com"]
+      )
+      email = ActionMailer::Base.deliveries.last
+
+      assert_equal "DEFAULT@EMAIL.COM", email.from.first
+
+      ArtVandelay.from_address = nil
+    end
+
+    test "it has a default body" do
+      ArtVandelay::Export.new(User.all).email_csv(
+        to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+        from: "sender@example.com"
+      )
+      email = ActionMailer::Base.deliveries.last
+
+      assert_equal "User export", email.body.raw_source
+    end
+
+    test "it can set the body" do
+      ArtVandelay::Export.new(User.all).email_csv(
+        to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+        from: "sender@example.com",
+        body: "CUSTOM BODY"
+      )
+      email = ActionMailer::Base.deliveries.last
+
+      assert_equal "CUSTOM BODY", email.body.raw_source
     end
   end
 end


### PR DESCRIPTION
This commit introduces a feature allowing the caller to send the exported CSV in
an email.

In order to keep this feature small, there is no custom mailer or template.
Instead, we simply invoke `ActionMailer::Base.mail` and define the properties
inline.
