### PR TITLE
Export data in batches

### DIFF
--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -2,41 +2,70 @@ require "art_vandelay/version"
 require "art_vandelay/engine"
 
 module ArtVandelay
-  mattr_accessor :filtered_attributes, :from_address
+  mattr_accessor :filtered_attributes, :from_address, :in_batches_of
   @@filtered_attributes = [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]
+  @@in_batches_of = 10000
 
   def self.setup
     yield self
   end
 
   class Export
+    class Result
+      attr_reader :csv_exports
+
+      def initialize(csv_exports)
+        @csv_exports = csv_exports
+      end
+    end
+
     # TODO attributes: self.filtered_attributes
-    def initialize(records, export_sensitive_data: false, attributes: [])
+    def initialize(records, export_sensitive_data: false, attributes: [], in_batches_of: ArtVandelay.in_batches_of)
       @records = records
       @export_sensitive_data = export_sensitive_data
       @attributes = attributes
+      @in_batches_of = in_batches_of
     end
 
     def csv
-      CSV.parse(generate_csv, headers: true)
+      csv_exports = []
+
+      if records.is_a?(ActiveRecord::Relation)
+        records.in_batches(of: in_batches_of) do |relation|
+          csv_exports << CSV.parse(generate_csv(relation), headers: true)
+        end
+      elsif records.is_a?(ActiveRecord::Base)
+        csv_exports << CSV.parse(generate_csv(records), headers: true)
+      end
+
+      Result.new(csv_exports)
     end
 
     def email_csv(to:, from: ArtVandelay.from_address, subject: "#{model_name} export", body: "#{model_name} export")
       mailer = ActionMailer::Base.mail(to: to, from: from, subject: subject, body: body)
-      mailer.attachments[file_name.to_s] = csv.to_csv
+      csv_exports = csv.csv_exports
+
+      csv_exports.each.with_index(1) do |csv, index|
+        if csv_exports.one?
+          mailer.attachments[file_name] = csv
+        else
+          mailer.attachments[file_name(suffix: "-#{index}")] = csv
+        end
+      end
 
       mailer.deliver
     end
 
     private
 
-    attr_reader :records, :export_sensitive_data, :attributes
+    attr_reader :records, :export_sensitive_data, :attributes, :in_batches_of
 
-    def file_name
+    def file_name(**options)
       prefix = model_name.downcase
       timestamp = Time.current.in_time_zone("UTC").strftime("%Y-%m-%d-%H-%M-%S-UTC")
+      suffix = options[:suffix]
 
-      "#{prefix}-export-#{timestamp}.csv"
+      "#{prefix}-export-#{timestamp}#{suffix}.csv"
     end
 
     def filtered_values(attributes)
@@ -47,11 +76,15 @@ module ArtVandelay
       end
     end
 
-    def generate_csv
+    def generate_csv(relation)
       CSV.generate do |csv|
         csv << header
-        records.each do |record|
-          csv << row(record.attributes)
+        if relation.is_a?(ActiveRecord::Relation)
+          relation.each do |record|
+            csv << row(record.attributes)
+          end
+        elsif relation.is_a?(ActiveRecord::Base)
+          csv << row(records.attributes)
         end
       end
     end

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -12,30 +12,52 @@ class ArtVandelayTest < ActiveSupport::TestCase
     test "it has the correct default values" do
       filtered_attributes = ArtVandelay.filtered_attributes
       from_address = ArtVandelay.from_address
+      in_batches_of = ArtVandelay.in_batches_of
 
       assert_equal(
         [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn],
         filtered_attributes
       )
       assert_nil from_address
+      assert_equal 10000, in_batches_of
     end
   end
 
   class Export < ArtVandelayTest
     include ActionMailer::TestHelper
 
-    test "it returns a CSV::Table instance" do
+    test "it returns a ArtVandelay::Export::Result instance" do
       User.create!(email: "user@xample.com", password: "password")
 
       result = ArtVandelay::Export.new(User.all).csv
 
-      assert_instance_of CSV::Table, result
+      assert_instance_of ArtVandelay::Export::Result, result
     end
 
     test "it creates a CSV containing the correct data" do
       user = User.create!(email: "user@xample.com", password: "password")
 
-      csv = ArtVandelay::Export.new(User.all).csv
+      result = ArtVandelay::Export.new(User.all).csv
+      csv = result.csv_exports.first
+
+      assert_equal(
+        [
+          ["id", "email", "password", "created_at", "updated_at"],
+          [user.id.to_s, user.email.to_s, "[FILTERED]", user.created_at.to_s, user.updated_at.to_s]
+        ],
+        csv.to_a
+      )
+      assert_equal(
+        ["id", "email", "password", "created_at", "updated_at"],
+        csv.headers
+      )
+    end
+
+    test "it creates a CSV when passed one record" do
+      user = User.create!(email: "user@xample.com", password: "password")
+
+      result = ArtVandelay::Export.new(User.first).csv
+      csv = result.csv_exports.first
 
       assert_equal(
         [
@@ -56,7 +78,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
         config.filtered_attributes << :email
       end
 
-      csv = ArtVandelay::Export.new(User.all).csv
+      csv = ArtVandelay::Export.new(User.all).csv.csv_exports.first
 
       assert_equal(
         [
@@ -71,7 +93,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
     test "it allows for unfiltered exports" do
       user = User.create!(email: "user@xample.com", password: "password")
 
-      csv = ArtVandelay::Export.new(User.all, export_sensitive_data: true).csv
+      csv = ArtVandelay::Export.new(User.all, export_sensitive_data: true).csv.csv_exports.first
 
       assert_equal(
         [
@@ -85,7 +107,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
     test "it controlls what attributes are exported" do
       user = User.create!(email: "user@xample.com", password: "password")
 
-      csv = ArtVandelay::Export.new(User.all, attributes: [:id, "email"]).csv
+      csv = ArtVandelay::Export.new(User.all, attributes: [:id, "email"]).csv.csv_exports.first
 
       assert_equal(
         [
@@ -94,6 +116,35 @@ class ArtVandelayTest < ActiveSupport::TestCase
         ],
         csv.to_a
       )
+    end
+
+    test "it batches CSV exports" do
+      User.create!(email: "one@xample.com", password: "password")
+      User.create!(email: "two@xample.com", password: "password")
+
+      result = ArtVandelay::Export.new(User.all, in_batches_of: 1).csv
+      csv_1 = result.csv_exports.first
+      csv_2 = result.csv_exports.last
+
+      assert "one@example.com", csv_1.first["email"]
+      assert "two@example.com", csv_2.first["email"]
+    end
+
+    test "it can set the default batch size" do
+      User.create!(email: "one@xample.com", password: "password")
+      User.create!(email: "two@xample.com", password: "password")
+      ArtVandelay.setup do |config|
+        config.in_batches_of = 1
+      end
+
+      result = ArtVandelay::Export.new(User.all).csv
+      csv_1 = result.csv_exports.first
+      csv_2 = result.csv_exports.last
+
+      assert "one@example.com", csv_1.first["email"]
+      assert "two@example.com", csv_2.first["email"]
+
+      ArtVandelay.in_batches_of = 10000
     end
 
     test "it emails a CSV" do
@@ -124,7 +175,63 @@ class ArtVandelayTest < ActiveSupport::TestCase
       assert_equal "user-export-1989-12-31-00-00-00-UTC.csv", csv.filename
     end
 
+    test "it emails a CSV when one record is passed" do
+      travel_to Date.new(1989, 12, 31).beginning_of_day
+      user = User.create!(email: "user@xample.com", password: "password")
+
+      assert_emails 1 do
+        ArtVandelay::Export.new(User.first).email_csv(
+          to: ["recipient_1@examaple.com", "recipient_2@example.com"],
+          from: "sender@example.com"
+        )
+      end
+
+      email = ActionMailer::Base.deliveries.last
+      csv = email.attachments.first
+
+      assert_equal(
+        ["recipient_1@examaple.com", "recipient_2@example.com"],
+        email.to
+      )
+      assert_equal(
+        [
+          ["id", "email", "password", "created_at", "updated_at"],
+          [user.id.to_s, user.email.to_s, "[FILTERED]", user.created_at.to_s, user.updated_at.to_s]
+        ],
+        CSV.parse(csv.body.raw_source)
+      )
+      assert_equal "user-export-1989-12-31-00-00-00-UTC.csv", csv.filename
+    end
+
+    test "it emails multiple CSV attachments" do
+      travel_to Date.new(1989, 12, 31).beginning_of_day
+      User.create!(email: "one@example.com", password: "password")
+      User.create!(email: "two@example.com", password: "password")
+
+      assert_emails 1 do
+        ArtVandelay::Export.new(User.all, in_batches_of: 1).email_csv(
+          to: ["recipient_1@examaple.com"],
+          from: "sender@example.com"
+        )
+      end
+
+      email = ActionMailer::Base.deliveries.last
+      csv_1 = email.attachments.first
+      csv_2 = email.attachments.last
+
+      assert_match "one@example.com", csv_1.body.raw_source
+      assert_match "two@example.com", csv_2.body.raw_source
+      assert_equal "user-export-1989-12-31-00-00-00-UTC-1.csv", csv_1.filename
+      assert_equal "user-export-1989-12-31-00-00-00-UTC-2.csv", csv_2.filename
+    end
+
+    test "it raises an error if there is no data to export" do
+      skip
+    end
+
     test "it has a default subject" do
+      User.create!(email: "user@xample.com", password: "password")
+
       ArtVandelay::Export.new(User.all).email_csv(
         to: ["recipient_1@examaple.com", "recipient_2@example.com"],
         from: "sender@example.com"
@@ -135,6 +242,8 @@ class ArtVandelayTest < ActiveSupport::TestCase
     end
 
     test "it can set the subject" do
+      User.create!(email: "user@xample.com", password: "password")
+
       ArtVandelay::Export.new(User.all).email_csv(
         to: ["recipient_1@examaple.com", "recipient_2@example.com"],
         from: "sender@example.com",
@@ -146,6 +255,8 @@ class ArtVandelayTest < ActiveSupport::TestCase
     end
 
     test "it can set a from address" do
+      User.create!(email: "user@xample.com", password: "password")
+
       ArtVandelay::Export.new(User.all).email_csv(
         to: ["recipient_1@examaple.com", "recipient_2@example.com"],
         from: "FROM@EMAIL.COM"
@@ -156,6 +267,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
     end
 
     test "it can set a default from address" do
+      User.create!(email: "user@xample.com", password: "password")
       ArtVandelay.setup do |config|
         config.from_address = "DEFAULT@EMAIL.COM"
       end
@@ -170,6 +282,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
     end
 
     test "it has a default body" do
+      User.create!(email: "user@xample.com", password: "password")
       ArtVandelay::Export.new(User.all).email_csv(
         to: ["recipient_1@examaple.com", "recipient_2@example.com"],
         from: "sender@example.com"
@@ -180,6 +293,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
     end
 
     test "it can set the body" do
+      User.create!(email: "user@xample.com", password: "password")
       ArtVandelay::Export.new(User.all).email_csv(
         to: ["recipient_1@examaple.com", "recipient_2@example.com"],
         from: "sender@example.com",


### PR DESCRIPTION
This commit ensures data is exported in batches to avoid large CSV files
or long running queries.

The default batch size is 10,000 to align with the default value for
[in_batches], but this default can be overridden.

[in_batches]: https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-in_batches
