### PR TITLE
Require a from address

### DIFF
--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -11,6 +11,9 @@ module ArtVandelay
     yield self
   end
 
+  class Error < StandardError
+  end
+
   class Export
     class Result
       attr_reader :csv_exports
@@ -43,6 +46,10 @@ module ArtVandelay
     end
 
     def email_csv(to:, from: ArtVandelay.from_address, subject: "#{model_name} export", body: "#{model_name} export")
+      if from.nil?
+        raise ArtVandelay::Error, "missing keyword: :from. Alternatively, set a value on ArtVandelay.from_address"
+      end
+
       mailer = ActionMailer::Base.mail(to: to, from: from, subject: subject, body: body)
       csv_exports = csv.csv_exports
 

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -175,6 +175,16 @@ class ArtVandelayTest < ActiveSupport::TestCase
       assert_equal "user-export-1989-12-31-00-00-00-UTC.csv", csv.filename
     end
 
+    test "it requires a from address" do
+      User.create!(email: "user@xample.com", password: "password")
+
+      assert_raises ArtVandelay::Error do
+        ArtVandelay::Export.new(User.all).email_csv(
+          to: ["recipient_1@examaple.com"]
+        )
+      end
+    end
+
     test "it emails a CSV when one record is passed" do
       travel_to Date.new(1989, 12, 31).beginning_of_day
       user = User.create!(email: "user@xample.com", password: "password")


### PR DESCRIPTION
This commit ensures the caller passes a value to the `from` keyword, or
configures a default from address.

There is probably room for improvement here, since there is no default
value, and thus, we're setting the value to nil by default.
