### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Have you ever been on a project where, out of nowhere, someone asks you to send 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "art_vandelay", git: "https://github.com/thoughtbot/art_vandelay"
+gem "art_vandelay"
 ```
 
 And then execute:


### PR DESCRIPTION
Now that the Gem has been released on RubyGems, we no longer need to
point to GitHub.
