### PR TITLE
Add option that allows stripping of whitespace for all values

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,14 @@ ArtVandelay::Import.new(model_name, **options)
 |Argument|Description|
 |--------|-----------|
 |`model_name`|The name of the model being imported. E.g. `:users`, `:user`, `"users"` or `"user"`|
-|`**options`|A hash of options. Available options are `rollback:`|
+|`**options`|A hash of options. Available options are `rollback:`, `strip:`|
 
 #### Options
 
 |Option|Description|
 |------|-----------|
 |`rollback:`|Whether the import should rollback if any of the records fails to save.|
+|`strip:`|Strips leading and trailing whitespace from all values, including headers.|
 
 #### ArtVandelay::Import#csv
 
@@ -219,6 +220,21 @@ end
 
 result = ArtVandelay::Import.new(:users).csv(csv_string, attributes: {email_address: :email, passcode: :password})
 # => #<ArtVandelay::Import::Result>
+```
+
+##### Stripping whitespace
+
+```ruby
+csv_string = CSV.generate do |csv|
+  csv << ["email_address  ", " passcode  "]
+  csv << ["  george@vandelay_industries.com  ", "  bosco  "]
+end
+
+result = ArtVandelay::Import.new(:users, strip: true).csv(csv_string, attributes: {email_address: :email, passcode: :password})
+# => #<ArtVandelay::Import::Result>
+
+result.rows_accepted
+# => [{:row=>["george@vandelay_industries.com", "bosco"], :id=>1}]
 ```
 
 ## 🙏 Contributing

--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -179,12 +179,10 @@ module ArtVandelay
       attributes = attributes.stringify_keys
 
       if strip
-        params = row.to_h.stringify_keys.transform_keys do |key|
+        row.to_h.stringify_keys.transform_keys do |key|
           attributes[key.strip] || key.strip
-        end
-
-        params.transform_values do |value|
-          value.strip
+        end.tap do |new_params|
+          new_params.transform_values!(&:strip)
         end
       else
         row.to_h.stringify_keys.transform_keys do |key|

--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -142,6 +142,7 @@ module ArtVandelay
     def initialize(model_name, **options)
       @options = options.symbolize_keys
       @rollback = options[:rollback]
+      @strip = options[:strip]
       @model_name = model_name
     end
 
@@ -164,7 +165,7 @@ module ArtVandelay
 
     private
 
-    attr_reader :model_name, :rollback
+    attr_reader :model_name, :rollback, :strip
 
     def active_record
       model_name.to_s.classify.constantize
@@ -177,8 +178,18 @@ module ArtVandelay
     def build_params(row, attributes)
       attributes = attributes.stringify_keys
 
-      row.to_h.stringify_keys.transform_keys do |key|
-        attributes[key] || key
+      if strip
+        params = row.to_h.stringify_keys.transform_keys do |key|
+          attributes[key.strip] || key.strip
+        end
+
+        params.transform_values do |value|
+          value.strip
+        end
+      else
+        row.to_h.stringify_keys.transform_keys do |key|
+          attributes[key] || key
+        end
       end
     end
 

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -336,6 +336,26 @@ class ArtVandelayTest < ActiveSupport::TestCase
       assert_equal "s3kure!", user_2.password
     end
 
+    test "it strips whitespace when strip configuration is passed" do
+      csv_string = CSV.generate do |csv|
+        csv << [" email ", "   password  "]
+        csv << ["  email_1@example.com ", " s3krit "]
+        csv << [" email_2@example.com ", " s3kure!  "]
+      end
+
+      assert_difference("User.count", 2) do
+        ArtVandelay::Import.new(:users, strip: true).csv(csv_string)
+      end
+
+      user_1 = User.find_by!(email: "email_1@example.com")
+      user_2 = User.find_by!(email: "email_2@example.com")
+
+      assert_equal "email_1@example.com", user_1.email
+      assert_equal "s3krit", user_1.password
+      assert_equal "email_2@example.com", user_2.email
+      assert_equal "s3kure!", user_2.password
+    end
+
     test "it sets the headers" do
       csv_string = CSV.generate do |csv|
         csv << %w[email_1@example.com s3krit]
@@ -375,7 +395,7 @@ class ArtVandelayTest < ActiveSupport::TestCase
       assert_equal "s3kure!", user_2.password
     end
 
-    test "strips whitespace if strip configuration is passed" do
+    test "strips whitespace if strip configuration is passed when using custom attributes" do
       csv_string = CSV.generate do |csv|
         csv << ["email_address ", "  passcode "]
         csv << ["  email_1@example.com ", " s3krit "]


### PR DESCRIPTION
This adds a new option for the Importer that will automatically strip leading and trailing whitespace from all fields, including header values.