### PR TITLE
Adjust the typography for apostrophe in Rails >= 7.1

### DIFF
--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -426,13 +426,23 @@ class ArtVandelayTest < ActiveSupport::TestCase
         ],
         result.rows_accepted
       )
-      assert_equal(
-        [
-          row: ["invalid@example.com", nil],
-          errors: {password: ["can't be blank"]}
-        ],
-        result.rows_rejected
-      )
+      if Rails.version >= "7.1"
+        assert_equal(
+          [
+            row: ["invalid@example.com", nil],
+            errors: {password: ["can’t be blank"]}
+          ],
+          result.rows_rejected
+        )
+      else
+        assert_equal(
+          [
+            row: ["invalid@example.com", nil],
+            errors: {password: ["can't be blank"]}
+          ],
+          result.rows_rejected
+        )
+      end
     end
 
     test "it returns results when rollback is enabled" do


### PR DESCRIPTION
In Rails >= 7.1, the apostrophe typography was changed to the right single quotation mark ([Ref](https://github.com/rails/rails/pull/45463)).

closes #20 
