### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,17 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         rails-version:
           - "7.0"
           - "6.1"
           - "6.0"
           - "main"
+        exclude:
+          - ruby-version: "2.7"
+            rails-version: "main"
+          - ruby-version: "3.2"
+            rails-version: "6.0"
 
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
@@ -25,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        uses: ruby/setup-ruby@8a45918450651f5e4784b6031db26f4b9f76b251
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies


### PR DESCRIPTION
Also excluded the Ruby 2.7 / Rails main combination, as that's not a supported combination.

This runs green on my fork.