### PR TITLE
Adds basic support for queries generated by `#find_by_sql`

### DIFF
--- a/lib/art_vandelay.rb
+++ b/lib/art_vandelay.rb
@@ -41,7 +41,9 @@ module ArtVandelay
       elsif records.is_a?(ActiveRecord::Base)
         csv_exports << CSV.parse(generate_csv(records), headers: true)
       elsif records.is_a?(Array)
-        csv_exports << CSV.parse(generate_csv(records), headers: true)
+        if records.any?
+          csv_exports << CSV.parse(generate_csv(records), headers: true)
+        end
       end
 
       Result.new(csv_exports)
@@ -125,6 +127,8 @@ module ArtVandelay
         records.model_name.name
       when Array
         records.first.model_name.name
+      else
+        raise "Unsupported export: #{records.class}"
       end
     end
 

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -72,6 +72,26 @@ class ArtVandelayTest < ActiveSupport::TestCase
       )
     end
 
+    test "it creates a CSV when passed an Array of ActiveRecord instances" do
+      user = User.create!(email: "user@xample.com", password: "password")
+      export = User.find_by_sql("SELECT id, 'custom_value' AS custom_field FROM users")
+
+      result = ArtVandelay::Export.new(export).csv
+      csv = result.csv_exports.first
+
+      assert_equal(
+        [
+          ["id", "custom_field"],
+          [user.id.to_s, "custom_value"]
+        ],
+        csv.to_a
+      )
+      assert_equal(
+        ["id", "custom_field"],
+        csv.headers
+      )
+    end
+
     test "it controlls what data is filtered" do
       user = User.create!(email: "user@xample.com", password: "password")
       ArtVandelay.setup do |config|

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -92,6 +92,12 @@ class ArtVandelayTest < ActiveSupport::TestCase
       )
     end
 
+    test "it does not create a CSV when passed an empty Array" do
+      result = ArtVandelay::Export.new([]).csv
+
+      assert_empty result.csv_exports
+    end
+
     test "it controlls what data is filtered" do
       user = User.create!(email: "user@xample.com", password: "password")
       ArtVandelay.setup do |config|


### PR DESCRIPTION
Relates to #32

Allows exporting data that was generated by [find_by_sql][]. This can be desirable when the caller is required to export a calculated field that is not stored directly on the table as demonstrated below.

```ruby
export = User.find_by_sql("SELECT id, 'custom_value' AS custom_field FROM users")
ArtVandelay::Export.new(export).csv
```

As such, this feature does not support the `in_batches_of` option, since
that would be the responsibility of the query.

This feature also does not (yet) support the `attributes` option.

[find_by_sql]: https://api.rubyonrails.org/classes/ActiveRecord/Querying.html#method-i-find_by_sql
