### PR TITLE
Add `Import#json`, `Export#json`, and `Export#email`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,29 @@ Unreleased
 
 - Drops support for Ruby 3.0, since it is EOL.
 - Drops support for Rails 6.
+- Adds `Import#json`, `Export#json`, and `Export#email` (#34).
+
+  The `#json` interface for importing and exporting JSON have been designed to work the same way they already work for the CSV interfaces. For example:
+
+  ```ruby
+  json_string = [
+    {
+      email: "george@vandelay_industries.com",
+      password: "bosco"
+    }
+  ].to_json
+
+  result = ArtVandelay::Import.new(:users).json(json_string, attributes: {email_address: :email, passcode: :password})
+  ```
+
+  `ArtVandelay::Export#email_csv` has been changed to a more-generic `ArtVandelay::Export#email` method that takes a new `:format` option. The new option defaults to `:csv` but can also be used with `:json`. Since the old `#email_csv` method no longer exists, you'll need to update your application code accordingly. For example:
+
+  ```diff
+  -ArtVandelay::Export.email_csv(to: my_email_address)
+  +ArtVandelay::Export.email(to: my_email_address)
+  ```
+
+  *Benjamin Wil*
 
 0.2.0 (June 15, 2023)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ end
 
 ### 📤 Exporting
 
+Art Vandelay supports exporting CSVs and JSON files.
+
 ```ruby
 ArtVandelay::Export.new(records, export_sensitive_data: false, attributes: [], in_batches_of: ArtVandelay.in_batches_of)
 ```
@@ -57,7 +59,7 @@ ArtVandelay::Export.new(records, export_sensitive_data: false, attributes: [], i
 |`records`|An [Active Record Relation](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html) or an instance of an Active Record. E.g. `User.all`, `User.first`, `User.where(...)`, `User.find_by`|
 |`export_sensitive_data`|Export sensitive data. Defaults to `false`. Can be configured with `ArtVandelay.filtered_attributes`.|
 |`attributes`|An array attributes to export. Default to all.|
-|`in_batches_of`|The number of records that will be exported into each CSV. Defaults to 10,000. Can be configured with `ArtVandelay.in_batches_of`|
+|`in_batches_of`|The number of records that will be exported into each file. Defaults to 10,000. Can be configured with `ArtVandelay.in_batches_of`|
 
 #### ArtVandelay::Export#csv
 
@@ -72,6 +74,21 @@ csv_exports = result.csv_exports
 
 csv = csv_exports.first.to_a
 # => [["id", "email", "password", "created_at", "updated_at"], ["1", "user@example.com", "[FILTERED]", "2022-10-25 09:20:28 UTC", "2022-10-25 09:20:28 UTC"]]
+```
+
+#### ArtVandelay::Export#json
+
+Returns an instance of `ArtVandelay::Export::Result`.
+
+```ruby
+result = ArtVandelay::Export.new(User.all).json
+# => #<ArtVandelay::Export::Result>
+
+json_exports = result.json_exports
+# => [#<CSV::Table>, #<CSV::Table>, ...]
+
+json = JSON.parse(json_exports.first)
+# => [{"id"=>1, "email"=>"user@example.com", "password"=>"[FILTERED]", "created_at"=>"2022-10-25 09:20:28.123Z", "updated_at"=>"2022-10-25 09:20:28.123Z"}]
 ```
 
 ##### Exporting Sensitive Data

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Have you ever been on a project where, out of nowhere, someone asks you to send 
 
 - 🕶 Automatically [filters out sensitive information](#%EF%B8%8F-configuration).
 - 🔁 Export data [in batches](#exporting-in-batches).
-- 📧 [Email](#artvandelayexportemail_csv) exported data.
+- 📧 [Email](#artvandelayexportemail) exported data.
 - 📥 [Import data](#-importing) from a CSV or JSON file.
 
 ## ✅ Installation
@@ -121,12 +121,12 @@ csv_size = result.csv_exports.first.size
 # => 100
 ```
 
-#### ArtVandelay::Export#email_csv
+#### ArtVandelay::Export#email
 
-Emails the recipient(s) CSV exports as attachments.
+Emails the recipient(s) exports as attachments.
 
 ```ruby
-email_csv(to:, from: ArtVandelay.from_address, subject: "#{model_name} export", body: "#{model_name} export")
+email(to:, from: ArtVandelay.from_address, subject: "#{model_name} export", body: "#{model_name} export")
 ```
 
 |Argument|Description|
@@ -135,15 +135,17 @@ email_csv(to:, from: ArtVandelay.from_address, subject: "#{model_name} export", 
 |`from`|The email address of the sender.|
 |`subject`|The email subject. Defaults to the following pattern: "User export"|
 |`body`|The email body. Defaults to the following pattern: "User export"|
+|`format`|The format of the export file. Either `:csv` or `:json`.|
 
 ```ruby
 ArtVandelay::Export
   .new(User.where.not(confirmed: nil))
-  .email_csv(
+  .email(
     to: ["george@vandelay_industries.com", "kel_varnsen@vandelay_industries.com"],
     from: "noreply@vandelay_industries.com",
     subject: "List of confirmed users",
-    body: "Here's an export of all confirmed users in our database."
+    body: "Here's an export of all confirmed users in our database.",
+    format: :json
   )
 # => ActionMailer::Base#mail: processed outbound mail in...
 ```


### PR DESCRIPTION
_This pull request closes #26._

This pull request allows the importing and exporting of JSON files. Previously only CSVs were supported. The interfaces for importing and exporting JSON have been designed to work the same way they already work for the CSV interfaces.

I've added documentation to the README for all of the JSON interfaces, so I won't go into more detail here. Refer to the changes to the README.

## Breaking changes

There is one breaking change here, which is that the `Export#email_csv` method has been renamed to `Export#email`. It takes a new `:format` argument which defaults to `:csv`. Users will need to update their application code accordingly:

```diff
-Export.email_csv(to: my_email)
+Export.email(to: my_email)
```
