### PR TITLE
Update supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         rails-version:
-          - "6.1"
           - "7.0"
           - "7.1"
           - "main"
-        exclude:
-          - ruby-version: "3.0"
-            rails-version: "main"
 
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+Unreleased
+
+- Drops support for Ruby 3.0, since it is EOL.
+- Drops support for Rails 6.
+
 0.2.0 (June 15, 2023)
 
 Add option that allows stripping of whitespace for all values (#19)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Actions
 Demo](https://github.com/thoughtbot/art_vandelay/actions/workflows/ci.yml/badge.svg)](https://github.com/thoughtbot/art_vandelay/actions/workflows/ci.yml)
 
-Art Vandelay is an importer/exporter for Rails 6.0 and higher.
+Art Vandelay is an importer/exporter for Rails 7.0 and higher.
 
 Have you ever been on a project where, out of nowhere, someone asks you to send them a CSV of data? You think to yourself, “Ok, cool. No big deal. Just gimme five minutes”, but then that five minutes turns into a few hours. Art Vandelay can help. 
 

--- a/art_vandelay.gemspec
+++ b/art_vandelay.gemspec
@@ -3,6 +3,7 @@ require_relative "lib/art_vandelay/version"
 Gem::Specification.new do |spec|
   spec.name = "art_vandelay"
   spec.version = ArtVandelay::VERSION
+  spec.required_ruby_version = ArtVandelay::MINIMUM_RUBY_VERSION
   spec.authors = ["Steve Polito"]
   spec.email = ["stevepolito@hey.com"]
   spec.homepage = "https://github.com/thoughtbot/art_vandelay"
@@ -18,5 +19,5 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails"
+  spec.add_dependency "rails", ArtVandelay::RAILS_VERSION
 end

--- a/lib/art_vandelay/version.rb
+++ b/lib/art_vandelay/version.rb
@@ -1,3 +1,5 @@
 module ArtVandelay
-  VERSION = "0.2.0"
+  VERSION = "0.2.0".freeze
+  RAILS_VERSION = ">= 7.0".freeze
+  MINIMUM_RUBY_VERSION = ">= 3.1".freeze
 end

--- a/test/art_vandelay_test.rb
+++ b/test/art_vandelay_test.rb
@@ -6,6 +6,14 @@ class ArtVandelayTest < ActiveSupport::TestCase
     test "it has a version number" do
       assert ArtVandelay::VERSION
     end
+
+    test "it has a supported Rails version" do
+      assert_equal ">= 7.0", ArtVandelay::RAILS_VERSION
+    end
+
+    test "it has a supported Ruby version" do
+      assert_equal ">= 3.1", ArtVandelay::MINIMUM_RUBY_VERSION
+    end
   end
 
   class Setup < ArtVandelayTest


### PR DESCRIPTION
Drops support for Ruby 3.0, since it is EOL. Also drops support for
Rails 6, since Rails 8 is slated to be released in September.
